### PR TITLE
Corrected distance calculation formula

### DIFF
--- a/environment.ts
+++ b/environment.ts
@@ -300,7 +300,7 @@ let sc_byte = 0
 
         // read pulse
         let d = pins.pulseIn(pin, PulseValue.High, 23000)  // 8 / 340 = 
-        let distance = d * 10 * 5 / 3 / 58
+        let distance = d * 10 / 58
 
         if (distance > 4000) distance = 0
 


### PR DESCRIPTION
The distance calculation formula for the ultrasonic sensor is not correct. In this pull request, I am proposing a simple correction.

**The short answer:**  
distance (in cm) = uS / 58
distance (in mm) = uS * 10 / 58

**Longer answer:**  
I will help myself with [arduinoaleman's explanation](https://forum.arduino.cc/t/ultrasonic-sensor-distance-equation-and-the-factor-0-0001657/429435/4) posted on the official Arduino forum in 2017:

> The speed of sound is 343 meter/sec at 20 degrees Celsius. That is 34300 centimeters/sec.
> 
> That is 0,03434 cm/microsecond or 0,01352 inches/microsecond.
> 
> The sensor measures the distance from and to the object, so we have to divide this value by 2.
> 
> That gives us 0,01717 cm/microsecond or 0,006760 inches/microsecond.
> 
> distance = pulsewidth (µs) * 0,01717 cm/µs. distance = pulsewidth (µs) * 0,006760 inches/µs.
> 
> Instead of dividing by 2 and then multiplying by 0,03434 some code (for centimeters) uses a division by 58,24 which is mathematically the same. This saves one floating point operation and makes the code much harder to understand.

